### PR TITLE
PR 2022-08-03 16.52

### DIFF
--- a/js/kbd.js
+++ b/js/kbd.js
@@ -244,7 +244,8 @@ class AidKeyHelper {
     }
 
     isEnabled(mapIndex) {
-        if (mapIndex < 0) return false;
+        if (mapIndex < 0)    { return false; }
+        if (mapIndex === AidKeyMapIndex.Enter) { return true;  } // Always enabled.
         return this.isAttention(mapIndex) || this.isFunction(mapIndex);
     }
 


### PR DESCRIPTION
Case 21355 CHECK(ER) does not work at Runtime (fails because AutoPostBackKey="Enter" not enabled) (#5)

AutoPostBackKey="Enter" now adds the proper Event handlers.