### PR TITLE
Strings padded with blanks of ValuesText crashed JavaScript.

### DIFF
--- a/js/dropdown.js
+++ b/js/dropdown.js
@@ -97,9 +97,6 @@ class DropDown {
             }
         }
 
-        if (state === 'unquoted')
-            vals.push(valuesEos.substring(iLexeme, i));
-
         return vals;
     }
 


### PR DESCRIPTION
Strings padded with blanks to the right of ValuesText were causing JavaScript crash.