### PR TITLE
Validation for dates w/ 'min' or 'max' no calendar.

### DIFF
--- a/js/asna-data-attr.js
+++ b/js/asna-data-attr.js
@@ -38,6 +38,7 @@ const AsnaDataAttrName = {
     // Calendar
     CALENDAR_NAMES: 'data-asna-calendar-names',
     CALENDAR_OPTIONS: 'data-asna-calendar-options',
+    CALENDAR_INPUT_RANGE_CONSTRAINT: 'data-asna-calendar-range-constraint', // internal
 
     // Decimal Date (date whose value is a decimal)
     DEC_DATE_OPTIONS: 'data-asna-decdate-options',

--- a/js/calendar/calendar.js
+++ b/js/calendar/calendar.js
@@ -9,6 +9,7 @@ export { theCalendar as Calendar };
 
 import { CalendarUI } from './calendar-ui.js';
 import { Base64 } from '../base-64.js';
+import { AsnaDataAttrName } from '../asna-data-attr.js';
 
 class Calendar {
 
@@ -66,6 +67,11 @@ class Calendar {
         }
         wrapper.appendChild(button);
         button.addEventListener('click', (event) => { this.handleCalendarOnClickEvent(event, input, options); return false; });
+
+        if (!input.readonly && input.getAttribute('min') || input.getAttribute('max')) {
+            input.setAttribute(AsnaDataAttrName.CALENDAR_INPUT_RANGE_CONSTRAINT, options.dateFormat);
+            input.addEventListener('input', () => input.setCustomValidity('')); // Clear validation error
+        }
     }
 
     show(input, options) {

--- a/js/page.js
+++ b/js/page.js
@@ -500,6 +500,8 @@ class Page {
             return;
         }
 
+        Validate.validateDateConstraint(form);
+
         if (!Validate.reportFormValidity(form)) {
             this.suspendAsyncPost = false;
             return;

--- a/js/validate.js
+++ b/js/validate.js
@@ -7,10 +7,11 @@
 
 export { Validate };
 
-import { PageAlert } from '../js/page-alert.js';
-import { AsnaDataAttrName } from '../js/asna-data-attr.js';
-import { AidKeyHelper } from '../js/kbd.js';
-import { Base64, UnicodeToUTF8 } from '../js/base-64.js';
+import { PageAlert } from './page-alert.js';
+import { AsnaDataAttrName } from './asna-data-attr.js';
+import { AidKeyHelper } from './kbd.js';
+import { Base64, UnicodeToUTF8 } from './base-64.js';
+import { IbmDate } from './calendar/ibm-date.js';
 
 const OK_TEXT = 'Ok';
 const MANDATORY_FAILED_MSG = {
@@ -95,6 +96,38 @@ class Validate {
 
         PageAlert.show(errMsg, OK_TEXT, firstFailedEl);
         return false;
+    }
+
+    static validateDateConstraint(form) {
+        const dates = form.querySelectorAll(`[${AsnaDataAttrName.CALENDAR_INPUT_RANGE_CONSTRAINT}]`);
+
+        for (let i = 0, l = dates.length; i < l; i++) {
+            const input = dates[i];
+            const minIsoDate = input.getAttribute('min');
+            const maxIsoDate = input.getAttribute('max');
+
+            if (!(minIsoDate || maxIsoDate)) { continue; } // unexpected (why did it have CALENDAR_INPUT_RANGE_CONSTRAINT?)
+
+            const dateFormat = input.getAttribute(AsnaDataAttrName.CALENDAR_INPUT_RANGE_CONSTRAINT);
+            let errorMsg = input.getAttribute('title');
+            if (!errorMsg)
+                errorMsg = 'Date out of range!';
+            const date = IbmDate.textToDate(dateFormat, input.value);
+            if (minIsoDate) {
+                const minDate = new Date(minIsoDate + 'T00:00:00');
+                if (date < minDate) {
+                    input.setCustomValidity(errorMsg);
+                    continue;
+                }
+            }
+            if (maxIsoDate) {
+                const maxDate = new Date(maxIsoDate + 'T00:00:00');
+                if (date > maxDate) {
+                    input.setCustomValidity(errorMsg);
+                    continue;
+                }
+            }
+        }
     }
 
     static setDirty(event) {


### PR DESCRIPTION
Implement validation for dates with 'min' or 'max' attributes, when no calendar selection is used.