### PR TITLE
5250 Isolate double-byte elements.

### DIFF
--- a/css/5250.css
+++ b/css/5250.css
@@ -14,7 +14,7 @@ body {
     padding:0px;
 }
 
-.bterm-render-section, .bterm-cursor {
+.bterm-render-section, .bterm-render-section-dbyte, .bterm-cursor {
     font-family: var(--term-font-family);
     font-size: var(--term-font-size);
     margin: 0;
@@ -23,11 +23,15 @@ body {
     user-select: none;
 }
 
-.bterm-render-section {
+.bterm-render-section, .bterm-render-section-dbyte {
     display: block;
     white-space: pre;
     overflow: hidden;
     border-bottom-width: 1px; /* Used for underline */
+}
+
+.bterm-render-section-dbyte {
+    letter-spacing: 0.10rem;
 }
 
 .bterm-cursor {

--- a/js/bterm/buffer-mapping.js
+++ b/js/bterm/buffer-mapping.js
@@ -8,10 +8,12 @@
 export { BufferMapping };
 
 import { TerminalDOM } from './terminal-dom.js';
+import { DBCS } from './terminal-dbcs.js';
 
 class BufferMapping {
-    constructor(_5250cols) {
+    constructor(_5250cols, hasChinese) {
         this._5250cols = _5250cols;
+        this.hasChinese = hasChinese;
     }
     coordToPos(row, col) {
         return col + row * this._5250cols;
@@ -21,8 +23,18 @@ class BufferMapping {
         return pos / this._5250cols >> 0;  // Integer division  
     }
 
-    colFromPos(pos) {
-        return pos % this._5250cols >> 0; // Integer modulo
+    colFromPos(pos, regBuffer) {
+        if (!this.hasChinese || !regBuffer) {
+            return pos % this._5250cols >> 0; // Integer modulo
+        }
+
+        const initialPos = this.rowFromPos(pos) * this._5250cols;
+        let col = 0;
+        for (let i = initialPos; i < pos && i < regBuffer.length; i++) {
+            col += DBCS.isChinese(regBuffer[i]) ? 2 : 1;
+        }
+
+        return col;
     }
     static rowToPixel(row, termLayout) {
         return row * parseFloat(TerminalDOM.getGlobalVarValue('--term-row-height'));

--- a/js/bterm/terminal-screen.js
+++ b/js/bterm/terminal-screen.js
@@ -13,7 +13,7 @@ import { Validate } from './terminal-validate.js';
 import { TerminalRender } from './terminal-render.js';
 import { TerminalDOM } from './terminal-dom.js';
 
-// const _debug = true; // Comment line for production !!!
+const _debug = false;
 
 class Screen {
     constructor(rows, cols, msgLight) {
@@ -29,9 +29,9 @@ class Screen {
 
         this.cursorPos = {};
         this.size = { rows: rows, cols: cols, msgLight: msgLight ? msgLight : false };
-        this.mapping = new BufferMapping(this.size.cols);
+        this.mapping = new BufferMapping(this.size.cols, false);
 
-        if (typeof _debug !== 'undefined' ) {
+        if (_debug) {
             this.saveDebugState();
             this.handleDebugIntervalTimerEvent = this.handleDebugIntervalTimerEvent.bind(this);
             this.debugInterval = setInterval(this.handleDebugIntervalTimerEvent, 1000);
@@ -66,8 +66,8 @@ class Screen {
         return null;
     }
 
-    setMapping(cols) {
-        this.mapping = new BufferMapping(cols);
+    setMapping(cols, hasChinese) {
+        this.mapping = new BufferMapping(cols, hasChinese);
     }
 
     loadAttributes(a) {

--- a/js/bterm/terminal.js
+++ b/js/bterm/terminal.js
@@ -695,7 +695,7 @@ class Terminal {
         const toPos = selRange.to;
         let pos = selRange.from;
         let text = '';
-        const map = new BufferMapping(this.termLayout._5250.cols);
+        const map = new BufferMapping(this.termLayout._5250.cols, false /* PENDING: review */);
 
         while (pos <= toPos) {
             const rowBefore = map.rowFromPos(pos);
@@ -735,7 +735,7 @@ class Terminal {
         const toPos = selRange.to;
 
 
-        const map = new BufferMapping(this.termLayout._5250.cols);
+        const map = new BufferMapping(this.termLayout._5250.cols, false /* PENDING: review */);
 
         while (pos <= toPos) {
             const colBefore = map.colFromPos(pos);
@@ -1117,7 +1117,7 @@ class Terminal {
     }
 
     processNewLine() {
-        const map = new BufferMapping(this.termLayout._5250.cols);
+        const map = new BufferMapping(this.termLayout._5250.cols, false /* PENDING: review */);
 
         const initialPos = this.regScr.coordToPos(this.cursor.row, this.cursor.col);
         this.cursor.col = 0;
@@ -1224,7 +1224,7 @@ class Terminal {
 
         let fromPos = this.regScr.coordToPos(this.cursor.row, this.cursor.col);
         let pos = fromPos;
-        const map = new BufferMapping(this.termLayout._5250.cols);
+        const map = new BufferMapping(this.termLayout._5250.cols, false /* PENDING: review */);
 
         if (nonbreaking && nonbreaking === 'nb') {
             let done = false;
@@ -1808,7 +1808,7 @@ class Terminal {
         if (stream.errorRegenerationBuffer && stream.errorRegenerationBuffer.length > 0) {
             this.errScr = new Screen(newSize.rows, newSize.cols, newSize.msgLight);
             this.errScr.loadBuffer(stream.errorRegenerationBuffer);
-            this.errScr.setMapping(newSize.cols);
+            this.errScr.setMapping(newSize.cols, false);
             this.errScr.loadAttributes(stream.errorAttributes);
             this.errScr.loadCursorPosition(stream.errorCursorPosition);
         }
@@ -2249,7 +2249,7 @@ class Terminal {
             else if (this.autoAdvance && (!this.isCursorInInputPos() || (dbcsType !== 'n' && (atDbcsEnd = this.atDbcsFieldFullPos(sa.field))))) {
                 if (atDbcsEnd) {
                     const tmpPos = coordToPos(sa.field.row, sa.field.col) + sa.field.len;
-                    const map = new BufferMapping(this.termLayout._5250.cols);
+                    const map = new BufferMapping(this.termLayout._5250.cols, false /* PENDING: review */);
                     this.cursor.setPosition(map.rowFromPos(tmpPos), map.colFromPos(tmpPos));
                 }
                 this.moveToNextInputArea(this.cursor.row, this.cursor.col);
@@ -2558,7 +2558,7 @@ class Terminal {
     }
 
     moveToPos(pos, dirtyInputFld) {
-        const map = new BufferMapping(this.termLayout._5250.cols);
+        const map = new BufferMapping(this.termLayout._5250.cols, false /* PENDING: review */);
 
         this.cursor.setPosition(map.rowFromPos(pos), map.colFromPos(pos));
         this.updateCursor(dirtyInputFld);
@@ -2964,7 +2964,7 @@ class Terminal {
     }
 
     addNewLineRowChanged(pos, rowBefore) {
-        const map = new BufferMapping(this.termLayout._5250.cols);
+        const map = new BufferMapping(this.termLayout._5250.cols, false /* PENDING: review */);
 
         if (map.rowFromPos(pos) > rowBefore) {
             return '\r\n';


### PR DESCRIPTION
Double-byte characters have less letter spacing than needed to fill two single byte positions. By Isolating the double-byte strings segments, an extended CSS style can be applied to compensate for the missing spacing.