### PR TITLE
5250 ending with re-direct not respecting EoJ page.

### DIFF
--- a/js/bterm/terminal.js
+++ b/js/bterm/terminal.js
@@ -2708,6 +2708,7 @@ class Terminal {
         if (stream.redirectUrl) {
             this.submit.activeFKey = 'Redirecting';
             window.location = stream.redirectUrl;
+            return;
         }
 
         this.initTerminal();


### PR DESCRIPTION
Exiting from 5250 session due to server redirect should respect the requested page (EoJ in this case). Was showing ExpiredSession.