### PR TITLE
Two fixes related to Decimal field rendering.

### DIFF
--- a/css/expo.css
+++ b/css/expo.css
@@ -207,7 +207,8 @@ body {
 
 \*-------------------------------------------*/
 .dds-dec-field-alignment {
-    text-align: right;
+    text-align: right !important;
+    white-space: pre;
     padding-right: 0.25em;
 }
 


### PR DESCRIPTION
1. Subfiles with dec fields should right align. 
2. For EditCode(s) that format negative sign on the right, the positive blank should be preserved.