### PR TITLE
Feedback Cursor marker Support

### DIFF
--- a/css/expo.css
+++ b/css/expo.css
@@ -853,6 +853,23 @@ div:has(> input#rendering-fake-data-close:checked) {
     display: none;
 }
 
+.cursor-marker {
+    position: fixed; /* Stays in place even on scroll */
+    top: 0;
+    left: 0;
+    width: clamp(0.6rem, 0.75rem, 1rem);
+    height: clamp(0.6rem, 0.75rem, 1rem);
+    background-color: rgba(0, 255, 0, 0.8); /* 80% opacity bright green */
+    box-shadow: 0 0 6px rgba(0, 255, 0, 0.9); /* Glow effect */
+    border: 1px solid #00cc00;
+    border-radius: 50%; /* Circular dot */
+    pointer-events: none; /* So it doesn't block clicks */
+    transform: translate(-50%, -50%); /* Center the dot on the coordinates */
+    z-index: 9999; /* Above everything */
+    opacity: 0; /* Start invisible; will be shown when clicked */
+    transition: opacity 0.2s ease; /* Optional subtle fade */
+}
+
 /*-------------------------------------------*\
     Synon Escape
 

--- a/js/feedback-area.js
+++ b/js/feedback-area.js
@@ -38,6 +38,28 @@ class FeedbackArea {
         }
     }
 
+    overrideRowColFeedback(form, main, cursorMarker, gridRowHeight) {
+        if (form && main && cursorMarker) {
+            const input = form[FEEDBACK_HIDDEN_FIELD_NAME.atRowCol];
+            if (input && 'value' in input) {
+                const mainRect = main.getBoundingClientRect();
+                const gridColWidth = getComputedStyle(document.documentElement).getPropertyValue('--dds-grid-col-width');
+
+                // Get marker position relative to viewport
+                const markerRect = cursorMarker.getBoundingClientRect();
+                // Calculate marker center position relative to main element
+                const markerCenterX = (markerRect.left + markerRect.width / 2) - mainRect.left;
+                const markerCenterY = (markerRect.top + markerRect.height / 2) - mainRect.top;
+
+                let col = Math.floor(markerCenterX / parseInt(gridColWidth)) + 1; // +1 because columns are 1-based
+                let row = Math.floor(markerCenterY / parseInt(gridRowHeight)) + 1; // +1 because rows are 1-based (assuming square cells)
+
+                // alert(`atRowCol: ${row},${col}`);
+                FeedbackArea.setHiddenFieldValue(form, FEEDBACK_HIDDEN_FIELD_NAME.atRowCol, `${row},${col}`);
+            }
+        }
+    }
+
     updateElementFeedback(form, el, activeWinSpecs, sflCursorRrn) {
         if (form) { // Clear the last value ...
             FeedbackArea.setHiddenFieldValue(form, FEEDBACK_HIDDEN_FIELD_NAME.atCursorLocation, '');

--- a/js/kbd.js
+++ b/js/kbd.js
@@ -180,7 +180,7 @@ class Kbd {
             if (firstSflCtrlName) {
                 const firstCtrlStore = SubfilePagingStore.getSflCtlStore(firstSflCtrlName);
                 if (firstCtrlStore) {
-                    action = Kbd.handleRoll(aidKey, sflCtrlStore);
+                    action = Kbd.handleRoll(aidKey, firstCtrlStore);
                 }
             }
 

--- a/js/page.js
+++ b/js/page.js
@@ -611,6 +611,14 @@ class Page {
             return;
         }
 
+        const main = form.querySelector(MAIN_SELECTOR);
+        if (main) {
+            const cursorMarker = main.querySelector('div.cursor-marker');
+            if (cursorMarker && cursorMarker.dataset.clicked) {
+                FeedbackArea.overrideRowColFeedback(form, main, cursorMarker, DdsGrid.calcRowHeight(main))
+            }
+        }
+
         const delaySubmit = DdsWindow.prepareForSubmit(form, this.handleHtmlToImageCompleteEvent, this.handleHtmlToImageFilterEvent );
 
         WaitForResponseAnimation.prepareWaitAnimation(true);

--- a/js/page.js
+++ b/js/page.js
@@ -167,6 +167,33 @@ class Page {
         this.resetLastClickOnFocus = true;
 
         DynamicList.init(thisForm);
+
+        const cursorMarker = main.querySelector('div.cursor-marker');
+        if (cursorMarker) {
+            main.addEventListener('click', (event) => {
+                if (event.ctrlKey) { // Only when Ctrl key is pressed
+                    event.preventDefault();
+
+                    const x = event.clientX;
+                    const y = event.clientY;
+
+                    // Update position (using transform for better performance)
+                    cursorMarker.style.transform = `translate(${x}px, ${y}px) translate(-50%, -50%)`;
+
+                    // Make it briefly visible/pulse if hidden by default
+                    cursorMarker.style.opacity = '1';
+                    setTimeout(() => {
+                        cursorMarker.style.opacity = '0.6';
+                    }, 300);
+
+                    // Mark with data attribute
+                    cursorMarker.dataset.clicked = 'true';
+                } else { // Clear marker when Ctrl is not pressed
+                    cursorMarker.style.opacity = '0';
+                    delete cursorMarker.dataset.clicked;
+                }
+            });
+        }
     }
 
     static setupAutoPostback(form, aidKeyBitmap) {


### PR DESCRIPTION
Now when a Razor Page defines element <div class="cursor-marker"></div> inside <main role="main"> the user can use a selector (green dot) to select a point on the main (DDS file) and it active before submitting page, it will report the feedback (row,col) information.
To enable the cursor marker selector, use Ctrl + left-mouse-click.  (To make it disappear, click again without the Ctrl key down). 